### PR TITLE
Have spotless run on :compileJava instead of :build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,4 +139,4 @@ spotless {
     }
 }
 
-build.dependsOn spotlessApply
+compileJava.dependsOn spotlessApply


### PR DESCRIPTION
This allows it to format on both build and deploy, rather than just build